### PR TITLE
Exit if we are not in a git repo

### DIFF
--- a/git-quick-stats
+++ b/git-quick-stats
@@ -180,6 +180,9 @@ function changelogs() {
     git log --pretty=format:"- %s%n%b" --since="$(git show -s --format=%ad `git rev-list --all --max-count=1`)" | sort -nr
 }
 
+# Check if we are currently in a git repo.
+git rev-parse --is-inside-work-tree > /dev/null
+
 if [ $# -eq 1 ]
   then
      case $1 in


### PR DESCRIPTION
Currently, the menu will be shown if I run git-quick-stats outside of a git repo. Any of the options presented in the menu will fail with the error message `fatal: Not a git repository (or any of the parent directories): .git`.

This PR adds a check for a git repo before parsing any input or displaying the menu. If a git repo is not found, the error message `fatal: Not a git repository (or any of the parent directories): .git` is printed out.

I've tested this by running git-quick-stats outside of a git repo:
``` bash
$ pwd
/tmp/not-a-git-repo
$ git-quick-stats
fatal: Not a git repository (or any of the parent directories): .git
```

Running git-quick-stats inside a git repo:
```bash
$ pwd
/tmp/a-git-repo
$ git-quick-stats
# ...cleared screen... #
 Generate:
  1) Contribution stats (by author)
  2) Git changelogs
  3) My daily status
 List:
  4) Branch tree view (last 10)
  5) All branches (sorted by most recent commit)
  6) All contributors (sorted by name)
  7) Git commits per author
  8) Git commits per day
 Suggest:
  9) Code reviewers (based on git history)

Please enter a menu option or press enter to exit.
```

Running git-quick-stats with an invalid command inside a git repo. I wanted to validate that this addition doesn't add any output:
``` bash
$ pwd
/tmp/not-a-git-repo
$ git-quick-stats foobar
Invalid argument. Possible arguments: suggestReviewers, detailedGitStats, commitsPerDay, commitsPerAuthor, myDailyStats, contributors, branchTree, branchesByDate, changelogs
```