### PR TITLE
Added detailed stats for today grouped by user.

### DIFF
--- a/git-quick-stats
+++ b/git-quick-stats
@@ -36,21 +36,22 @@ function show_menu() {
     echo -e ""
     echo -e "${RED_TEXT} Generate: ${NORMAL}"
     echo -e "${MENU} ${NUMBER} 1)${MENU} Contribution stats (by author) ${NORMAL}"
-    echo -e "${MENU} ${NUMBER} 2)${MENU} Git changelogs (last $_limit)${NORMAL}"
-    echo -e "${MENU} ${NUMBER} 3)${MENU} Git changelogs by author ${NORMAL}"
-    echo -e "${MENU} ${NUMBER} 4)${MENU} My daily status ${NORMAL}"
+    echo -e "${MENU} ${NUMBER} 2)${MENU} Contribution stats today (by author) ${NORMAL}"
+    echo -e "${MENU} ${NUMBER} 3)${MENU} Git changelogs (last $_limit)${NORMAL}"
+    echo -e "${MENU} ${NUMBER} 4)${MENU} Git changelogs by author ${NORMAL}"
+    echo -e "${MENU} ${NUMBER} 5)${MENU} My daily status ${NORMAL}"
     echo -e "${RED_TEXT} List: ${NORMAL}"
-    echo -e "${MENU} ${NUMBER} 5)${MENU} Branch tree view (last $_limit)${NORMAL}"
-    echo -e "${MENU} ${NUMBER} 6)${MENU} All branches (sorted by most recent commit) ${NORMAL}"
-    echo -e "${MENU} ${NUMBER} 7)${MENU} All contributors (sorted by name) ${NORMAL}"
-    echo -e "${MENU} ${NUMBER} 8)${MENU} Git commits per author ${NORMAL}"
-    echo -e "${MENU} ${NUMBER} 9)${MENU} Git commits per date ${NORMAL}"
-    echo -e "${MENU} ${NUMBER} 10)${MENU} Git commits per month ${NORMAL}"
-    echo -e "${MENU} ${NUMBER} 11)${MENU} Git commits per weekday ${NORMAL}"
-    echo -e "${MENU} ${NUMBER} 12)${MENU} Git commits per hour ${NORMAL}"
-    echo -e "${MENU} ${NUMBER} 13)${MENU} Git commits by author per hour ${NORMAL}"
+    echo -e "${MENU} ${NUMBER} 6)${MENU} Branch tree view (last $_limit)${NORMAL}"
+    echo -e "${MENU} ${NUMBER} 7)${MENU} All branches (sorted by most recent commit) ${NORMAL}"
+    echo -e "${MENU} ${NUMBER} 8)${MENU} All contributors (sorted by name) ${NORMAL}"
+    echo -e "${MENU} ${NUMBER} 9)${MENU} Git commits per author ${NORMAL}"
+    echo -e "${MENU} ${NUMBER} 10)${MENU} Git commits per date ${NORMAL}"
+    echo -e "${MENU} ${NUMBER} 11)${MENU} Git commits per month ${NORMAL}"
+    echo -e "${MENU} ${NUMBER} 12)${MENU} Git commits per weekday ${NORMAL}"
+    echo -e "${MENU} ${NUMBER} 13)${MENU} Git commits per hour ${NORMAL}"
+    echo -e "${MENU} ${NUMBER} 14)${MENU} Git commits by author per hour ${NORMAL}"
     echo -e "${RED_TEXT} Suggest: ${NORMAL}"
-    echo -e "${MENU} ${NUMBER} 14)${MENU} Code reviewers (based on git history) ${NORMAL}"
+    echo -e "${MENU} ${NUMBER} 15)${MENU} Code reviewers (based on git history) ${NORMAL}"
     echo -e ""
     echo -e "${ENTER_LINE}Please enter a menu option or ${RED_TEXT}press enter to exit. ${NORMAL}"
     read opt
@@ -64,10 +65,18 @@ function option_picked() {
     echo ""
 }
 
+function detailedGitStatsTodayByAuthor() {
+    option_picked 'Contribution stats today (by author):'
+    _detailedGitStats --since='00:00 today'
+}
+
 function detailedGitStats() {
     option_picked "Contribution stats (by author):"
+    _detailedGitStats $_since $_until
+}
 
-    git log --use-mailmap --no-merges --numstat --pretty="format:commit %H%nAuthor: %aN <%ae>%nDate:   %ad%n%n%w(0,4,4)%B%n" $_since $_until $_pathspec | LC_ALL=C awk '
+function _detailedGitStats() {
+    git log --use-mailmap --no-merges --numstat --pretty="format:commit %H%nAuthor: %aN <%ae>%nDate:   %ad%n%n%w(0,4,4)%B%n" "$@" $_pathspec | LC_ALL=C awk '
     function printStats(author) {
       printf "\t%s:\n", author
 
@@ -297,6 +306,9 @@ if [ $# -eq 1 ]
         "detailedGitStats")
            detailedGitStats
            ;;
+        "detailedGitStatsToday")
+           detailedGitStatsTodayByAuthor
+           ;;
         "branchTree")
            branchTree
            ;;
@@ -338,7 +350,7 @@ if [ $# -eq 1 ]
            commitsByMonth
            ;;
         *)
-           echo "Invalid argument. Possible arguments: suggestReviewers, detailedGitStats, commitsPerDay, commitsByMonth, commitsByWeekday, commitsByHour, commitsByAuthorByHour, commitsPerAuthor, myDailyStats, contributors, branchTree, branchesByDate, changelogs, changelogsByAuthor"
+           echo "Invalid argument. Possible arguments: suggestReviewers, detailedGitStats, detailedGitStatsTodayByAuthor, commitsPerDay, commitsByMonth, commitsByWeekday, commitsByHour, commitsByAuthorByHour, commitsPerAuthor, myDailyStats, contributors, branchTree, branchesByDate, changelogs, changelogsByAuthor"
            exit 1
            ;;
      esac
@@ -366,58 +378,62 @@ while [ opt != '' ]
            show_menu
            ;;
         2)
-           changelogs
+           detailedGitStatsTodayByAuthor
            show_menu
            ;;
         3)
+           changelogs
+           show_menu
+           ;;
+        4)
            author=''
            while [ -z "$author" ]; do read -p "Which author? " author; done
            changelogs "$author"
            show_menu
            ;;
-        4)
+        5)
            myDailyStats
            show_menu
            ;;
-        5)
+        6)
            branchTree
            show_menu
            ;;
-        6)
+        7)
            branchesByDate
            show_menu
            ;;
-        7)
+        8)
            contributors
            show_menu
            ;;
-        8)
+        9)
            commitsPerAuthor
            show_menu
            ;;
-        9)
+        10)
            commitsPerDay
            show_menu
            ;;
-        10)
+        11)
            commitsByMonth
            show_menu
            ;;
-        11)
+        12)
            commitsByWeekday
            show_menu
            ;;
-        12)
+        13)
            commitsByHour
            show_menu
            ;;
-        13)
+        14)
            author=''
 	   while [ -z "$author" ]; do read -p "Which author? " author; done
            commitsByHour "$author"
            show_menu
            ;;
-        14)
+        15)
            suggestReviewers
            show_menu
            ;;


### PR DESCRIPTION
Refactored the `detailedGitStats` function into two functions.
 - The `detailedGitStats` function has been renamed to
   `_detailedGitStats`.
 - The new `_detailedGitStats` function is almost identical to the
   old function, except it now doesn't output a title and it takes any
   number of arguments that get injected into the `git log` command (via
   the `$@` variable). This increases its flexibility, so that it can be
   used in other places without duplicating code.
 - The `detailedGitStats` function now outputs a title and calls the
   `_detailedGitStats` function with the `$_since` and `$_until`
   variables as parameters (these are passed to the `git log` command as
   described above).

Added the `detailedGitStatsTodayByAuthor` function.
 - This function gets the stats for today grouped by author.
 - It uses the `_detailedGitStats` function to do this by passing in the
   `--since` flag that get passed to `git log`.

Added the `detailedGitStatsTodayByAuthor` to the interactive menu.

Added the `detailedGitStatsTodayByAuthor` to the non-interactive list of
options that can be given as a command line argument.

Added the `detailedGitStatsTodayByAuthor` to the list of possible
arguments.

Tested options 1 and 2 with this repository and output is behaving as
expected.

Tested options 1 and 2 with `_GIT_SINCE` and `_GIT_UNTIL` and output is
behaving as expected.

This should resolve #3.