### PR TITLE
Makefile: Don't treat newline characters literally

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 PREFIX=/usr/local
-TASK_DONE = echo "\n✓ $@ done\n"
+TASK_DONE = echo -e "\n✓ $@ done\n"
 # files that need mode 755
 EXEC_FILES=git-quick-stats
 


### PR DESCRIPTION
Tested on Antergos KDE (Arch Linux)
Without supplying `-e` to `echo`, the Escape sequence `\n` is treated literally.