### PR TITLE
Fix ambiguous argument when author is not specified for commits by hour

### DIFF
--- a/git-quick-stats
+++ b/git-quick-stats
@@ -204,7 +204,7 @@ function commitsByHour() {
     for i in `seq -w 0 23`
     do
         echo -ne "\t$i\t"
-        echo $(git shortlog -n --no-merges --format='%ad %s' "$_author" $_since $_until | grep " $i:" | wc -l)
+        echo "$(git shortlog -n --no-merges --format='%ad %s' $_author $_since $_until | grep ' '$i: | wc -l)"
     done | awk '{ 
         count[$1] = $2 
         total += $2 


### PR DESCRIPTION
With `git-bash` for Windows, selecting option 12 (commits by hour) without specifying an author results in the following error (for each git command, one per hour):

````
fatal: ambiguous argument '': unknown revision or path not in the working tree.
Use '--' to separate paths from revisions, like this:
'git <command> [<revision>...] -- [<file>...]'
````

I believe the issue is caused because `_author` (set to `''`) is being read as `''` (two quotes) instead of an empty string. I'm not sure if it's exclusive to Windows. Either way, this pull request fixed it by quoting the entire command.