### PR TITLE
Makefile: set PREFIX to conditional assignment

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-PREFIX=/usr/local
+PREFIX ?= /usr/local
 TASK_DONE = echo -e "\n✓ $@ done\n"
 # files that need mode 755
 EXEC_FILES=git-quick-stats


### PR DESCRIPTION
When the variable PREFIX is provided on the command line, do not
override the value.

Signed-off-by: Dan Kalowsky <dank@deadmime.org>