### PR TITLE
fix: author not show fullname in contribution stats

### DIFF
--- a/git-quick-stats
+++ b/git-quick-stats
@@ -97,7 +97,8 @@ function detailedGitStats() {
     }
 
     /^Author:/ {
-      author = $2 " " $3
+      $1 = ""
+      author = $0
       commits[author] += 1
       commits["total"] += 1
     }


### PR DESCRIPTION
In contribution stats menu, if author name has more than 2 words, it just show the 1st and the 2nd word.
Sometimes it don't show the email address of a contributor.
This pull request fix that issue.