### PR TITLE
Changed non-interactive args and fixed main loop

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,10 +59,40 @@ Or you can use (non-interactive) direct execution:
 
 `git quick-stats <optional-command-to-execute-directly>`
 
-Possible arguments:
-> suggestReviewers, detailedGitStats, commitsByHour, commitsByWeekday, commitsByMonth, commitsPerDay, commitsPerAuthor, myDailyStats, contributors,
-branchTree, branchesByDate, changelogs, changelogsByAuthor
+Possible arguments in short and long form:
 
+```
+-r, --suggest-reviewers
+    show the best people to contact to review code
+-T, --detailed-git-stats
+    give a detailed list of git stats
+-d, --commits-per-day
+    displays a list of commits per day
+-m, --commits-by-month
+    displays a list of commits per month
+-w, --commits-by-weekday
+    displays a list of commits per weekday
+-o, --commits-by-hour
+    displays a list of commits per hour
+-A, --commits-by-author-by-hour
+    displays a list of commits per hour by author
+-a, --commits-per-author
+    displays a list of commits per author
+-S, --my-daily-stats
+    see your current daily stats
+-C, --contributors
+    see a list of everyone who contributed to the repo
+-b, --branch-tree
+    show an ASCII graph of the git repo branch history
+-D, --branches-by-date
+    show branches by date
+-c, --changelogs
+    see changelogs
+-L, --changelogs-by-author
+    see changelogs by author
+-h, -?, --help
+    display this help text in the terminal
+```
 
 #### Git log since / until
 

--- a/git-quick-stats
+++ b/git-quick-stats
@@ -24,6 +24,7 @@ function check_utils() {
     local HELP_MSG="not found. Please make sure this is installed and in PATH."
 
     command -v awk >/dev/null 2>&1 || { echo >&2 "awk ${HELP_MSG}"; exit 1; }
+    command -v basename >/dev/null 2>&1 || { echo >&2 "basename ${HELP_MSG}"; exit 1; }
     command -v cat > /dev/null 2>&1 || { echo >&2 "cat ${HELP_MSG}"; exit 1; }
     command -v column > /dev/null 2>&1 || { echo >&2 "column ${HELP_MSG}"; exit 1; }
     command -v echo > /dev/null 2>&1 || { echo >&2 "echo ${HELP_MSG}"; exit 1; }
@@ -36,6 +37,65 @@ function check_utils() {
     command -v tr > /dev/null 2>&1 || { echo >&2 "tr ${HELP_MSG}"; exit 1; }
     command -v uniq > /dev/null 2>&1 || { echo >&2 "uniq ${HELP_MSG}"; exit 1; }
     command -v wc > /dev/null 2>&1 || { echo >&2 "wc ${HELP_MSG}"; exit 1; }
+}
+
+function usage() { 
+    local program=$(basename "$0")
+
+    echo "
+NAME
+    ${program} - Simple and efficient way to access various stats in a git repo
+
+SYNOPSIS
+    For non-interactive mode: ${program} [OPTIONS]
+    For interactive mode: ${program}
+
+DESCRIPTION
+    Any git repository contains tons of information about commits, contributors,
+    and files. Extracting this information is not always trivial, mostly because
+    of a gadzillion options to a gadzillion git commands.
+
+    This program allows you to see detailed information about a git repository.
+
+OPTIONS
+    -r, --suggest-reviewers
+        show the best people to contact to review code
+    -T, --detailed-git-stats
+        give a detailed list of git stats
+    -d, --commits-per-day
+        displays a list of commits per day
+    -m, --commits-by-month
+        displays a list of commits per month
+    -w, --commits-by-weekday
+        displays a list of commits per weekday
+    -o, --commits-by-hour
+        displays a list of commits per hour
+    -A, --commits-by-author-by-hour
+        displays a list of commits per hour by author
+    -a, --commits-per-author
+        displays a list of commits per author
+    -S, --my-daily-stats
+        see your current daily stats
+    -C, --contributors
+        see a list of everyone who contributed to the repo
+    -b, --branch-tree
+        show an ASCII graph of the git repo branch history
+    -D, --branches-by-date
+        show branches by date
+    -c, --changelogs
+        see changelogs
+    -L, --changelogs-by-author
+        see changelogs by author
+    -h, -?, --help
+        display this help text in the terminal
+
+ADDITIONAL USAGE
+    You can set _GIT_SINCE and _GIT_UNTIL to limit the git time log
+        ex: export _GIT_SINCE=\"2017-20-01\"
+    You can set _GIT_LIMIT for limited output log
+        ex: export _GIT_LIMIT=20
+    You can exclude a directory from the stats by using pathspec
+        ex: export _GIT_PATHSPEC=':!directory'"
 }
 
 function show_menu() {
@@ -94,7 +154,7 @@ function detailedGitStats() {
       }
 
       if(commits["total"] > 0) {
-      	printf "\t  commits:       %d (%.0f%%)\n", commits[author], (commits[author] / commits["total"] * 100)
+        printf "\t  commits:       %d (%.0f%%)\n", commits[author], (commits[author] / commits["total"] * 100)
       }
 
       if ( first[author] != "" ) {
@@ -156,7 +216,7 @@ function commitsByMonth() {
     for i in Jan Feb Mar Apr May Jun Jul Aug Sep Oct Nov Dec
     do
         echo -en "\t$i\t"
-        echo $(git shortlog -n --no-merges --format='%ad %s' $_since $_until | grep " $i " | wc -l)
+        git shortlog -n --no-merges --format='%ad %s' $_since $_until | grep " $i " | wc -l
     done | awk '{ 
         count[$1] = $2 
         total += $2 
@@ -181,7 +241,7 @@ function commitsByWeekday() {
     for i in Mon Tue Wed Thu Fri Sat Sun
     do
         echo -en "\t$i\t"
-        echo $(git shortlog -n --no-merges --format='%ad %s' $_since $_until | grep "$i " | wc -l)
+        git shortlog -n --no-merges --format='%ad %s' $_since $_until | grep "$i " | wc -l
     done | awk '{
 
     }
@@ -311,147 +371,70 @@ check_utils
 # Check if we are currently in a git repo.
 git rev-parse --is-inside-work-tree > /dev/null
 
-if [ $# -eq 1 ]
-  then
-     case $1 in
-        "suggestReviewers")
-           suggestReviewers
-           ;;
-        "detailedGitStats")
-           detailedGitStats
-           ;;
-        "branchTree")
-           branchTree
-           ;;
-        "commitsPerDay")
-           commitsPerDay
-           ;;
-        "commitsPerAuthor")
-           commitsPerAuthor
-           ;;
-        "myDailyStats")
-           myDailyStats
-           ;;
-        "contributors")
-           contributors
-           ;;
-        "branchesByDate")
-           branchesByDate
-           ;;
-        "changelogs")
-           changelogs
-           ;;
-        "changelogsByAuthor")
-           author="${_GIT_AUTHOR:-}"
-           while [ -z "${author}" ]; do read -p "Which author? " author; done
-           changelogs "${author}"
-           ;;
-        "commitsByWeekday")
-           commitsByWeekday
-           ;;
-        "commitsByHour")
-           commitsByHour
-           ;;
-        "commitsByAuthorByHour")
-           author="${_GIT_AUTHOR:-}"
-	   while [ -z "${author}" ]; do read -p "Which author? " author; done
-           commitsByHour "${author}"
-           ;;
-        "commitsByMonth")
-           commitsByMonth
-           ;;
-        *)
-           echo "Invalid argument. Possible arguments: suggestReviewers, detailedGitStats, commitsPerDay, commitsByMonth, commitsByWeekday, commitsByHour, commitsByAuthorByHour, commitsPerAuthor, myDailyStats, contributors, branchTree, branchesByDate, changelogs, changelogsByAuthor"
-           exit 1
-           ;;
-     esac
-     exit 0;
+# Parse non-interative commands
+if [[ "$#" -eq 1 ]]; then
+    case "$1" in
+        -r|--suggest-reviewers) suggestReviewers;;
+        -T|--detailed-git-stats) detailedGitStats;;
+        -b|--branch-tree) branchTree;;
+        -d|--commits-per-day) commitsPerDay;;
+        -a|--commits-per-author) commitsPerAuthor;;
+        -S|--my-daily-stats) myDailyStats;;
+        -C|--contributors) contributors;;
+        -D|--branches-by-date) branchesByDate;;
+        -c|--changelogs) changelogs;;
+        -L|--changelogs-by-author)
+            author="${_GIT_AUTHOR:-}"
+            while [[ -z "${author}" ]]; do 
+                read -r -p "Which author? " author
+            done
+            changelogs "${author}";;
+        -w|--commits-by-weekday) commitsByWeekday;;
+        -o|--commits-by-hour) commitsByHour;;
+        -A|--commits-by-author-by-hour)
+            author="${_GIT_AUTHOR:-}"
+            while [[ -z "${author}" ]]; do 
+                read -r -p "Which author? " author
+            done
+            commitsByHour "${author}";;
+        -m|--commits-by-month) commitsByMonth;;
+        -h|-\?|--help) usage;;
+        *) echo "Invalid argument"; usage; exit 1;;
+    esac
+    exit 0;
 fi
+[[ "$#" -gt 1 ]] && { echo "Invalid arguments"; usage; exit 1; }
 
-[[ $# -gt 1 ]] && { echo "Usage: git quick-stats <optional-command-to-execute-directly>"; exit 1; }
-
+# Parse interactive commands
 clear
 show_menu
 
-while [ opt != '' ]
-    do
-    if [[ $opt = "" ]]; then
-        exit;
-    else
-        clear
-        case $opt in
-        1)
-           detailedGitStats
-           show_menu
-           ;;
-        2)
-           changelogs
-           show_menu
-           ;;
-        3)
-           author=''
-           while [ -z "${author}" ]; do read -p "Which author? " author; done
-           changelogs "${author}"
-           show_menu
-           ;;
-        4)
-           myDailyStats
-           show_menu
-           ;;
-        5)
-           branchTree
-           show_menu
-           ;;
-        6)
-           branchesByDate
-           show_menu
-           ;;
-        7)
-           contributors
-           show_menu
-           ;;
-        8)
-           commitsPerAuthor
-           show_menu
-           ;;
-        9)
-           commitsPerDay
-           show_menu
-           ;;
-        10)
-           commitsByMonth
-           show_menu
-           ;;
-        11)
-           commitsByWeekday
-           show_menu
-           ;;
-        12)
-           commitsByHour
-           show_menu
-           ;;
-        13)
-           author=''
-	   while [ -z "${author}" ]; do read -p "Which author? " author; done
-           commitsByHour "${author}"
-           show_menu
-           ;;
-        14)
-           suggestReviewers
-           show_menu
-           ;;
-        q)
-           exit
-           ;;
-        \n)
-           exit
-           ;;
-        *)
-           clear
-           option_picked "Pick an option from the menu"
-           show_menu
-           ;;
-
+while [[ "${opt}" != "" ]]; do
+    clear
+    case "${opt}" in
+        1) detailedGitStats; show_menu;;
+        2) changelogs; show_menu;;
+        3) author=""
+           while [[ -z "${author}" ]]; do 
+               read -r -p "Which author? " author
+           done
+           changelogs "${author}"; show_menu;;
+        4) myDailyStats; show_menu;;
+        5) branchTree; show_menu;;
+        6) branchesByDate; show_menu;;
+        7) contributors; show_menu;;
+        8) commitsPerAuthor; show_menu;;
+        9) commitsPerDay; show_menu;;
+       10) commitsByMonth; show_menu;;
+       11) commitsByWeekday; show_menu;;
+       12) commitsByHour; show_menu;;
+       13) author=""
+           while [[ -z "${author}" ]]; do 
+               read -r -p "Which author? " author
+           done
+           commitsByHour "${author}"; show_menu;;
+       14) suggestReviewers; show_menu;;
+       q|"\n") exit;;
+       *) clear; option_picked "Pick an option from the menu"; show_menu;;
     esac
-fi
 done

--- a/tests/commands_test.sh
+++ b/tests/commands_test.sh
@@ -3,17 +3,17 @@
 . tests/assert.sh -v
 
 src="./git-quick-stats"
-
-assert "$src fail" "Invalid argument. Possible arguments: suggestReviewers, detailedGitStats, commitsPerDay, commitsByMonth, commitsByWeekday, commitsByHour, commitsByAuthorByHour, commitsPerAuthor, myDailyStats, contributors, branchTree, branchesByDate, changelogs, changelogsByAuthor"
+#assert "$src fail" "Invalid argument\n\nNAME\n    git-quick-stats - Simple and efficient way to access various stats in a git repo\n\nSYNOPSIS\n    For non-interactive mode: git-quick-stats [OPTIONS]\n    For interactive mode: git-quick-stats\n\nDESCRIPTION\n    Any git repository contains tons of information about commits, contributors,\n    and files. Extracting this information is not always trivial, mostly because\n    of a gadzillion options to a gadzillion git commands.\n\n    This program allows you to see detailed information about a git repository.\n\nOPTIONS\n    suggestReviewers - see best people to contact to review code\n    detailedGitStats - displays a detailed list of git status\n    commitsPerDay - displays a list of commits per day\n    commitsByMonth - displays a list of commits per month\n    commitsByWeekday - displays a list of commits per weekday\n    commitsByHour - displays a list of commits per hour\n    commitsByAuthorByHour - see a list of commits per hour by author\n    commitsPerAuthor - displays a list of commits per author\n    myDailyStats - see your current daily stats\n    contributors - see a list of all contributors\n    branchTree - see an ASCII graph of the git repo\n    branchesByDate - show branches by date\n    changelogs - see changelogs\n    changelogsByAuthor - see changelogs by author\n\nADDITIONAL USAGE\n    You can set _GIT_SINCE and _GIT_UNTIL to limit the git time log\n        ex: export _GIT_SINCE=2017-20-01\n    You can set _GIT_LIMIT for limited output log\n        ex: export _GIT_LIMIT=20\n    You can exclude a directory from the stats by using pathspec\n        ex: export _GIT_PATHSPEC=':!directory'\n    \nCONTRIBUTION\n    For details regarding contribution, please see the contribution.md document\n\nLICENSE\n    This is under the MIT license. See LICENSE in the repo for more info"
+assert "$src fail" "Invalid argument\n\nNAME\n    git-quick-stats - Simple and efficient way to access various stats in a git repo\n\nSYNOPSIS\n    For non-interactive mode: git-quick-stats [OPTIONS]\n    For interactive mode: git-quick-stats\n\nDESCRIPTION\n    Any git repository contains tons of information about commits, contributors,\n    and files. Extracting this information is not always trivial, mostly because\n    of a gadzillion options to a gadzillion git commands.\n\n    This program allows you to see detailed information about a git repository.\n\nOPTIONS\n    -r, --suggest-reviewers\n        show the best people to contact to review code\n    -T, --detailed-git-stats\n        give a detailed list of git stats\n    -d, --commits-per-day\n        displays a list of commits per day\n    -m, --commits-by-month\n        displays a list of commits per month\n    -w, --commits-by-weekday\n        displays a list of commits per weekday\n    -o, --commits-by-hour\n        displays a list of commits per hour\n    -A, --commits-by-author-by-hour\n        displays a list of commits per hour by author\n    -a, --commits-per-author\n        displays a list of commits per author\n    -S, --my-daily-stats\n        see your current daily stats\n    -C, --contributors\n        see a list of everyone who contributed to the repo\n    -b, --branch-tree\n        show an ASCII graph of the git repo branch history\n    -D, --branches-by-date\n        show branches by date\n    -c, --changelogs\n        see changelogs\n    -L, --changelogs-by-author\n        see changelogs by author\n    -h, -?, --help\n        display this help text in the terminal\n\nADDITIONAL USAGE\n    You can set _GIT_SINCE and _GIT_UNTIL to limit the git time log\n        ex: export _GIT_SINCE=\"2017-20-01\"\n    You can set _GIT_LIMIT for limited output log\n        ex: export _GIT_LIMIT=20\n    You can exclude a directory from the stats by using pathspec\n        ex: export _GIT_PATHSPEC=':!directory'"
 assert_raises "$src fail" 1
 
-assert_contains "$src suggestReviewers" "Suggested code reviewers (based on git history)" 127
-assert_raises "$src suggestReviewers" 0
+assert_contains "$src --suggest-reviewers" "Suggested code reviewers (based on git history)" 127
+assert_raises "$src --suggest-reviewers" 0
 
-assert_contains "$src detailedGitStats" "Contribution stats" 127
-assert_raises "$src detailedGitStats" 0
+assert_contains "$src --detailed-git-stats" "Contribution stats" 127
+assert_raises "$src --detailed-git-stats" 0
 
-assert_contains "$src commitsPerDay" "Git commits per date" 127
-assert_raises "$src commitsPerDay" 0
+assert_contains "$src --commits-per-day" "Git commits per date" 127
+assert_raises "$src --commits-per-day" 0
 
 assert_end


### PR DESCRIPTION
* The previous commands were Lower CamelCase style and had no equivalent
  short options. If you wanted to see the branch tree via non-interactive
  mode, you always needed to supply "branchTree" as the passing argument to
  the git-quick-stats script.

  This commit changes the argument style to be more akin to the POSIX and GNU
  styles of arguments commonly seen in many other applications. As of this
  commit, there is no compatibility with legacy commands, so those who have
  been using the old commands will unfortunately need to get familiar with the
  new ones. All documentation and tests have been updated accordingly to
  reflect the new changes.

* The main interactive loop contained a non-variable constant that was only
  getting parsed correctly due to legacy fallback behavior. This commit fixes
  the main loop and cleans up the formatting a little bit.

* Added -r to more areas where read reads in a variable to help prevent
  it from mangling backslashes.

* Changed everything to use bash's built-in [[ notation and did some minor
  formatting changes to reduce the LOC.

* Removed some unnecessary echo statements and did some other minor cleanup.