### PR TITLE
Change format of _GIT_SINCE in help

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,8 +92,8 @@ Possible arguments in short and long form:
 You can set variable `_GIT_SINCE`, `_GIT_UNTIL` and limit the git log
 
 ```bash
-export _GIT_SINCE="2017-20-01"
-export _GIT_UNTIL="2017-22-01"
+export _GIT_SINCE="2017-01-20"
+export _GIT_UNTIL="2017-01-22"
 ```
 
 then run `git quick-stats` (affect all stats, except "My daily status" and "Git changelogs" )

--- a/git-quick-stats
+++ b/git-quick-stats
@@ -111,7 +111,7 @@ OPTIONS
 
 ADDITIONAL USAGE
     You can set _GIT_SINCE and _GIT_UNTIL to limit the git time log
-        ex: export _GIT_SINCE=\"2017-20-01\"
+        ex: export _GIT_SINCE=\"2017-01-20\"
     You can set _GIT_LIMIT for limited output log
         ex: export _GIT_LIMIT=20
     You can exclude a directory from the stats by using pathspec

--- a/git-quick-stats.1
+++ b/git-quick-stats.1
@@ -102,7 +102,7 @@ display this help text in the terminal
 You can set _GIT_SINCE and _GIT_UNTIL to limit the git time log, example:
 .IP
 .PP
-.B  export _GIT_SINCE="2017\-20\-01"
+.B  export _GIT_SINCE="2017\-01\-20"
 .IP
 .PP
 You can set _GIT_LIMIT for limited output log, example:


### PR DESCRIPTION
The format _GIT_SINCE is what `git --since` takes in which is YYYY-MM-DD.

Ref: https://git-scm.com/book/en/v2/Git-Basics-Viewing-the-Commit-History