### PR TITLE
Fixing OS X compatibility with merge feature

### DIFF
--- a/git-quick-stats
+++ b/git-quick-stats
@@ -23,9 +23,10 @@ _pathspec=${_GIT_PATHSPEC:-}
 # Exclusive shows only merge commits
 # Enable shows regular commits together with normal commits
 _merges=${_GIT_MERGE_VIEW:-}
-if [[ "${_merges,,}" == "exclusive" ]]; then 
+_merges=$(echo "$_merges" | awk '{print tolower($0)}')
+if [[ "${_merges}" == "exclusive" ]]; then 
     _merges="--merges"
-elif [[ "${_merges,,}" == "enable" ]]; then
+elif [[ "${_merges}" == "enable" ]]; then
     _merges=""
 else
     _merges="--no-merges"


### PR DESCRIPTION
* OS X utilizes an older version of GNU Bash. As such, certain features
  such as lowercase expansion can fail. This commit removes the Bash 4.0
  syntax in favor of a POSIX syntax with awk.