### PR TITLE
Fix divide by zero error during lines changed calc

### DIFF
--- a/git-quick-stats
+++ b/git-quick-stats
@@ -282,7 +282,14 @@ function detailedGitStats() {
         }
 
         if (first[author] != "") {
-            printf "\t  lines changed: %d\t(%.0f%%)\n", more[author] + less[author], ((more[author] + less[author])/ (more["total"]+ less["total"]) * 100 )
+            if ( ((more["total"] + less["total"]) * 100) > 0) {
+                printf "\t  lines changed: %d\t", more[author] + less[author]
+                printf "(%.0f%%)\n", ((more[author] + less[author]) / \
+                                      (more["total"] + less["total"]) * 100)
+            }
+            else {
+                printf "\t  lines changed: %d\t(0%)\n", more[author] + less[author]
+            }
             printf "\t  first commit:  %s\n", first[author]
             printf "\t  last commit:   %s\n", last[author]
         }

--- a/git-quick-stats
+++ b/git-quick-stats
@@ -288,7 +288,7 @@ function detailedGitStats() {
                                       (more["total"] + less["total"]) * 100)
             }
             else {
-                printf "\t  lines changed: %d\t(0%)\n", more[author] + less[author]
+                printf "\t  lines changed: %d\t(0%%)\n", (more[author] + less[author])
             }
             printf "\t  first commit:  %s\n", first[author]
             printf "\t  last commit:   %s\n", last[author]


### PR DESCRIPTION
* A new feature was implemented to show percentages when displaying
  detailed stats (menu options 1 and 2, or options -T and -R).
  However, the calculation during "lines changed" may cause an error
  within awk stating it cannot divide by zero as there is no check
  to see if the divisor is larger than zero.

  This commit attempts to fix that issue, albeit admittedly not in
  the most elegant way...

Tested on macOS 10.14, Ubuntu 16.04, and Fedora 30