### PR TITLE
Ability to use options for git log command

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@
 * [**Command-line arguments**](#command-line-arguments)
 * [**Git log since and until**](#git-log-since-and-until)
 * [**Git log limit**](#git-log-limit)
+* [**Git log options**](#git-log-options)
 * [**Git pathspec**](#git-pathspec)
 * [**Git merge view strategy**](#git-merge-view-strategy)
 * [**Color themes**](#color-themes)
@@ -144,6 +145,14 @@ You can set variable `_GIT_LIMIT` for limited output. It will affect the "change
 
 ```bash
 export _GIT_LIMIT=20
+```
+
+### Git log options
+
+You can set _GIT_LOG_OPTIONS for [git log options](https://git-scm.com/docs/git-log#_options):
+
+```bash
+export _GIT_LOG_OPTIONS="--ignore-all-space --ignore-blank-lines"
 ```
 
 ### Git pathspec

--- a/git-quick-stats
+++ b/git-quick-stats
@@ -541,7 +541,7 @@ function myDailyStats() {
     echo -e "\t" $(git -c log.showSignature=false log --use-mailmap \
                        --author="$(git config user.name)" $_merges \
                        --since=$(date "+%Y-%m-%dT00:00:00") \
-                       --until=$(date "+%Y-%m-%dT23:59:59") --reverse \
+                       --until=$(date "+%Y-%m-%dT23:59:59") --reverse $_log_options \
                        | grep commit | wc -l) "commits"
 }
 

--- a/git-quick-stats
+++ b/git-quick-stats
@@ -57,6 +57,14 @@ else
     _limit=10
 fi
 
+# Log options
+_log_options=${_GIT_LOG_OPTIONS:-}
+if [[ -n "${_log_options}" ]]; then
+    _log_options=$_log_options
+else 
+    _log_options=""
+fi
+
 # Default menu theme
 # Set the legacy theme by typing "export _MENU_THEME=legacy"
 _theme="${_MENU_THEME:=default}"
@@ -141,6 +149,8 @@ ADDITIONAL USAGE
         ex: export _GIT_SINCE=\"2017-01-20\"
     You can set _GIT_LIMIT for limited output log
         ex: export _GIT_LIMIT=20
+    You can set _GIT_LOG_OPTIONS for git log options
+        ex: export _GIT_LOG_OPTIONS=\"--ignore-all-space --ignore-blank-lines\"
     You can exclude directories or files from the stats by using pathspec
         ex: export _GIT_PATHSPEC=':!pattern'
     You can set _GIT_MERGE_VIEW to view merge commits with normal commits
@@ -257,7 +267,7 @@ function detailedGitStats() {
 
     git -c log.showSignature=false log ${_branch} --use-mailmap $_merges --numstat \
         --pretty="format:commit %H%nAuthor: %aN <%aE>%nDate:   %ad%n%n%w(0,4,4)%B%n" \
-        "$_since" "$_until" $_pathspec | LC_ALL=C awk '
+        "$_since" "$_until" $_log_options $_pathspec | LC_ALL=C awk '
         function printStats(author) {
         printf "\t%s:\n", author
 
@@ -338,7 +348,7 @@ function detailedGitStats() {
 function suggestReviewers() {
     optionPicked "Suggested code reviewers (based on git history):"
     git -c log.showSignature=false log --use-mailmap $_merges "$_since" "$_until" \
-        --pretty=%aN $_pathspec | head -n 100 | sort | uniq -c | sort -nr | LC_ALL=C awk '
+        --pretty=%aN $_log_options $_pathspec | head -n 100 | sort | uniq -c | sort -nr | LC_ALL=C awk '
     { args[NR] = $0; }
     END {
       for (i = 1; i <= NR; ++i) {
@@ -354,7 +364,7 @@ function suggestReviewers() {
 ################################################################################
 function jsonOutput() {
     optionPicked "Output log saved to file at: ${json_path}/output.json"
-    git -c log.showSignature=false log --use-mailmap $_merges "$_since" "$_until" \
+    git -c log.showSignature=false log --use-mailmap $_merges "$_since" "$_until" $_log_options \
         --pretty=format:'{%n  "commit": "%H",%n  "abbreviated_commit": "%h",%n  "tree": "%T",%n  "abbreviated_tree": "%t",%n  "parent": "%P",%n  "abbreviated_parent": "%p",%n  "refs": "%D",%n  "encoding": "%e",%n  "subject": "%s",%n  "sanitized_subject_line": "%f",%n  "body": "%b",%n  "commit_notes": "%N",%n  "author": {%n    "name": "%aN",%n    "email": "%aE",%n    "date": "%aD"%n  },%n  "commiter": {%n    "name": "%cN",%n    "email": "%cE",%n    "date": "%cD"%n  }%n},' \
         | sed "$ s/,$//" \
         | sed ':a;N;$!ba;s/\r\n\([^{]\)/\\n\1/g' \
@@ -374,7 +384,7 @@ function commitsByMonth() {
     do
         echo -en "\t$i\t"
         git -c log.showSignature=false shortlog -n $_merges --format='%ad %s' \
-            "$_since" "$_until" | grep " $i " | wc -l
+            "$_since" "$_until" $_log_options | grep " $i " | wc -l
     done | awk '{
         count[$1] = $2
         total += $2
@@ -406,7 +416,7 @@ function commitsByWeekday() {
     do
         echo -en "\t$counter\t$i\t"
         git -c log.showSignature=false shortlog -n $_merges --format='%ad %s' \
-            "$_since" "$_until" | grep "$i " | wc -l
+            "$_since" "$_until" $_log_options | grep "$i " | wc -l
         counter=$((counter+1))
     done | awk '{
     }
@@ -450,7 +460,7 @@ function commitsByHour() {
     do
         echo -ne "\t$i\t"
             git -c log.showSignature=false shortlog -n $_merges --format='%ad %s' \
-                "${_author}" "$_since" "$_until" | grep ' '$i: | wc -l
+                "${_author}" "$_since" "$_until" $_log_options | grep ' '$i: | wc -l
     done | awk '{
         count[$1] = $2
         total += $2
@@ -478,7 +488,7 @@ function commitsByHour() {
 function commitsPerDay() {
     optionPicked "Git commits per date:";
     git -c log.showSignature=false log --use-mailmap $_merges "$_since" "$_until" \
-        --date=short --format='%ad' $_pathspec | sort | uniq -c
+        --date=short --format='%ad' $_log_options $_pathspec | sort | uniq -c
 }
 
 ################################################################################
@@ -490,9 +500,9 @@ function commitsPerDay() {
 function commitsPerAuthor()  {
     optionPicked "Git commits per author:"
     local authorCommits=$(git -c log.showSignature=false log --use-mailmap $_merges \
-      "$_since" "$_until" | grep -i Author: | cut -c9-)
+      "$_since" "$_until" $_log_options | grep -i Author: | cut -c9-)
     local coAuthorCommits=$(git -c log.showSignature=false log --use-mailmap $_merges \
-    "$_since" "$_until" | grep -i Co-Authored-by: | cut -c21-)
+    "$_since" "$_until" $_log_options | grep -i Co-Authored-by: | cut -c21-)
 
     if [[ -z "${coAuthorCommits}" ]]
     then
@@ -543,7 +553,7 @@ function myDailyStats() {
 function contributors() {
     optionPicked "All contributors (sorted by name):"
     git -c log.showSignature=false log --use-mailmap $_merges "$_since" "$_until" \
-        --format='%aN' $_pathspec | sort -u | cat -n
+        --format='%aN' $_log_options $_pathspec | sort -u | cat -n
 }
 
 ################################################################################
@@ -556,7 +566,7 @@ function branchTree() {
     git -c log.showSignature=false log --use-mailmap --graph --abbrev-commit \
         "$_since" "$_until" --decorate \
         --format=format:'--+ Commit:  %h %n  | Date:    %aD (%ar) %n''  | Message: %s %d %n''  + Author:  %aN %n' \
-        --all | head -n $((_limit*5))
+        --all $_log_options | head -n $((_limit*5))
 }
 
 ################################################################################
@@ -592,7 +602,7 @@ function changelogs() {
         --use-mailmap \
         $_merges \
         --format="%cd" \
-        --date=short "${_author}" "$_since" "$_until" $_pathspec \
+        --date=short "${_author}" "$_since" "$_until" $_log_options $_pathspec \
         | sort -u -r | head -n $_limit \
         | while read DATE; do
               echo -e "\n[$DATE]"

--- a/git-quick-stats.1
+++ b/git-quick-stats.1
@@ -112,6 +112,10 @@ You can set _GIT_LIMIT for limited output log, example:
 .PP
 .B  export _GIT_LIMIT=20
 .PP
+You can set _GIT_LOG_OPTIONS for git log options, example:
+.PP
+.B  export _GIT_LOG_OPTIONS="--ignore-all-space --ignore-blank-lines"
+.PP
 You can exclude directories or files from the stats by using pathspec, example:
 .PP
 .B export _GIT_PATHSPEC=':!pattern'

--- a/tests/commands_test.sh
+++ b/tests/commands_test.sh
@@ -3,7 +3,74 @@
 . tests/assert.sh -v
 
 src="./git-quick-stats"
-assert "$src fail" "Invalid argument\n\nNAME\n    git-quick-stats - Simple and efficient way to access various stats in a git repo\n\nSYNOPSIS\n    For non-interactive mode: git-quick-stats [OPTIONS]\n    For interactive mode: git-quick-stats\n\nDESCRIPTION\n    Any git repository contains tons of information about commits, contributors,\n    and files. Extracting this information is not always trivial, mostly because\n    of a gadzillion options to a gadzillion git commands.\n\n    This program allows you to see detailed information about a git repository.\n\nOPTIONS\n    -r, --suggest-reviewers\n        show the best people to contact to review code\n    -T, --detailed-git-stats\n        give a detailed list of git stats\n    -R, --git-stats-by-branch\n        see detailed list of git stats by branch\n    -d, --commits-per-day\n        displays a list of commits per day\n    -m, --commits-by-month\n        displays a list of commits per month\n    -w, --commits-by-weekday\n        displays a list of commits per weekday\n    -o, --commits-by-hour\n        displays a list of commits per hour\n    -A, --commits-by-author-by-hour\n        displays a list of commits per hour by author\n    -a, --commits-per-author\n        displays a list of commits per author\n    -S, --my-daily-stats\n        see your current daily stats\n    -C, --contributors\n        see a list of everyone who contributed to the repo\n    -b, --branch-tree\n        show an ASCII graph of the git repo branch history\n    -D, --branches-by-date\n        show branches by date\n    -c, --changelogs\n        see changelogs\n    -L, --changelogs-by-author\n        see changelogs by author\n    -j, --json-output\n        save git log as a JSON formatted file to a specified area\n    -h, -?, --help\n        display this help text in the terminal\n\nADDITIONAL USAGE\n    You can set _GIT_SINCE and _GIT_UNTIL to limit the git time log\n        ex: export _GIT_SINCE=\"2017-01-20\"\n    You can set _GIT_LIMIT for limited output log\n        ex: export _GIT_LIMIT=20\n    You can exclude directories or files from the stats by using pathspec\n        ex: export _GIT_PATHSPEC=':!pattern'\n    You can set _GIT_MERGE_VIEW to view merge commits with normal commits\n        ex: export _GIT_MERGE_VIEW=enable\n    You can also set _GIT_MERGE_VIEW to only show merge commits\n        ex: export _GIT_MERGE_VIEW=exclusive\n    You can set _MENU_THEME to display the legacy color scheme\n        ex: export _MENU_THEME=legacy"
+assert "$src fail" "Invalid argument
+
+NAME
+    git-quick-stats - Simple and efficient way to access various stats in a git repo
+
+SYNOPSIS
+    For non-interactive mode: git-quick-stats [OPTIONS]
+    For interactive mode: git-quick-stats
+
+DESCRIPTION
+    Any git repository contains tons of information about commits, contributors,
+    and files. Extracting this information is not always trivial, mostly because
+    of a gadzillion options to a gadzillion git commands.
+
+    This program allows you to see detailed information about a git repository.
+
+OPTIONS
+    -r, --suggest-reviewers
+        show the best people to contact to review code
+    -T, --detailed-git-stats
+        give a detailed list of git stats
+    -R, --git-stats-by-branch
+        see detailed list of git stats by branch
+    -d, --commits-per-day
+        displays a list of commits per day
+    -m, --commits-by-month
+        displays a list of commits per month
+    -w, --commits-by-weekday
+        displays a list of commits per weekday
+    -o, --commits-by-hour
+        displays a list of commits per hour
+    -A, --commits-by-author-by-hour
+        displays a list of commits per hour by author
+    -a, --commits-per-author
+        displays a list of commits per author
+    -S, --my-daily-stats
+        see your current daily stats
+    -C, --contributors
+        see a list of everyone who contributed to the repo
+    -b, --branch-tree
+        show an ASCII graph of the git repo branch history
+    -D, --branches-by-date
+        show branches by date
+    -c, --changelogs
+        see changelogs
+    -L, --changelogs-by-author
+        see changelogs by author
+    -j, --json-output
+        save git log as a JSON formatted file to a specified area
+    -h, -?, --help
+        display this help text in the terminal
+
+ADDITIONAL USAGE
+    You can set _GIT_SINCE and _GIT_UNTIL to limit the git time log
+        ex: export _GIT_SINCE=\"2017-01-20\"
+    You can set _GIT_LIMIT for limited output log
+        ex: export _GIT_LIMIT=20
+    You can set _GIT_LOG_OPTIONS for git log options
+        ex: export _GIT_LOG_OPTIONS=\"--ignore-all-space --ignore-blank-lines\"
+    You can exclude directories or files from the stats by using pathspec
+        ex: export _GIT_PATHSPEC=':!pattern'
+    You can set _GIT_MERGE_VIEW to view merge commits with normal commits
+        ex: export _GIT_MERGE_VIEW=enable
+    You can also set _GIT_MERGE_VIEW to only show merge commits
+        ex: export _GIT_MERGE_VIEW=exclusive
+    You can set _MENU_THEME to display the legacy color scheme
+        ex: export _MENU_THEME=legacy"
+
 assert_raises "$src fail" 1
 
 assert_contains "$src --suggest-reviewers" "Suggested code reviewers (based on git history)" 127


### PR DESCRIPTION
A new feature was implemented which can use additional `git log` options.
You can set `_GIT_LOG_OPTIONS` variable to use git log options, 
eg: `export _GIT_LOG_OPTIONS="--ignore-all-space 
--ignore-cr-at-eol"`

See all `git log` options https://git-scm.com/docs/git-log#_options.
Tested on Ubuntu 16.04, Ubuntu 18.04 and Windows 10

Resolves #104