### PR TITLE
checkUtils: remove non-POSIX compliant features

### DIFF
--- a/git-quick-stats
+++ b/git-quick-stats
@@ -74,14 +74,14 @@ _theme="${_MENU_THEME:=default}"
 # ARGS: None
 # OUTS: None
 ################################################################################
-function checkUtils() {
-    local -r msg="not found. Please make sure this is installed and in PATH."
-    declare -ar utils=("awk" "basename" "cat" "column" "echo" "git" "grep" "head"
-        "seq" "sort" "tput" "tr" "uniq" "wc")
+checkUtils() {
+    readonly MSG="not found. Please make sure this is installed and in PATH."
+    readonly UTILS="awk basename cat column echo git grep head seq sort tput \
+		tr uniq wc"
 
-    for u in "${utils[@]}"
+    for u in $UTILS
     do
-        command -v "$u" >/dev/null 2>&1 || { echo >&2 "$u ${msg}"; exit 1; }
+        command -v "$u" >/dev/null 2>&1 || { echo >&2 "$u ${MSG}"; exit 1; }
     done
 }
 


### PR DESCRIPTION
### Description

Remove non-POSIX shell features from `checkUtils()` as these result in error during execution in a POSIX compliant shell (e.g. ash). 

### Changes

- [x] Remove `function`, `local `and `declare` as these are not supported/preferred features in a POSIX sh specification [1]. Furthermore, there is no suitable alternative solution (that i could find).
- [x] Change variables from read-only switch (-r) to explicit `readonly` command.
- [x] Change local variables to global variable type schema (e.g. all capitalized letters).
- [x] Change while-loop recursion from array elements to string elements as Arrays are not part of the POSIX specification [1]

### Sources

1. https://pubs.opengroup.org/onlinepubs/009695399/utilities/xcu_chap02.html#tag_02_09_05
2. https://pubs.opengroup.org/onlinepubs/9699919799/utilities/V3_chap02.html22