### PR TITLE
fix: correct localized decimal percent numbers

### DIFF
--- a/git-quick-stats
+++ b/git-quick-stats
@@ -518,9 +518,9 @@ function commitsPerAuthor()  {
           sum[author[i]]++; name[author[i]] = author[i]; total++;
         }
         for(i in sum) {
-          printf "\t%d,%s,%2.1f%%\n", sum[i], name[i], (100 * sum[i] / total)
+          printf "\t%d:%s:%2.1f%%\n", sum[i], name[i], (100 * sum[i] / total)
         }
-      }' | sort -n -r | column -t -s,
+      }' | sort -n -r | column -t -s:
 }
 
 ################################################################################


### PR DESCRIPTION
Hello.

In some (most European) locales, the decimal number part delimiter is actually a comma (`,`), while in other countries (UK, US, Asian) it is a dot (`.`): https://en.wikipedia.org/wiki/Decimal_separator
This breaks representation of percentage value of commits per author output. See here:
```
$ git-quick-stats --commits-per-author | head
Git commits per author:

	106  Lukas Mestan              58  2%
	22   Tom Ice                   12  1%
	7    Miodrag Tokić             3   8%
	6    jdeguzman                 3   3%
	4    Joshua de Guzman          2   2%
	3    Michael Czigler           1   6%
	2    Sandro                    1   1%
	2    Joopmicroop               1   1%
```
The fractional part of the last column got separated with space.
In `C` locale all is correct:
```
$ LANG=C git-quick-stats --commits-per-author | head
Git commits per author:

	106  Lukas Mestan                                       58.2%
	22   Tom Ice                                            12.1%
	7    Miodrag Toki\xc4\x87                               3.8%
	6    jdeguzman                                          3.3%
	4    Joshua de Guzman                                   2.2%
	3    Michael Czigler                                    1.6%
	2    frederic.cogny                                     1.1%
	2    Sandro                                             1.1%
```

In this PR I have changed internal field separator used to format the table to colon (`:`), which fixes the output:
```
$ ./git-quick-stats --commits-per-author | head
Git commits per author:

	106  Lukas Mestan              58,2%
	22   Tom Ice                   12,1%
	7    Miodrag Tokić             3,8%
	6    jdeguzman                 3,3%
	4    Joshua de Guzman          2,2%
	3    Michael Czigler           1,6%
	2    Sandro                    1,1%
	2    Joopmicroop               1,1%
``` 