### PR TITLE
test: fix assert_contains and its invocation

### DIFF
--- a/tests/assert.sh
+++ b/tests/assert.sh
@@ -17,11 +17,15 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+set -o nounset
+
 export DISCOVERONLY=${DISCOVERONLY:-}
 export DEBUG=${DEBUG:-}
 export STOP=${STOP:-}
 export INVARIANT=${INVARIANT:-}
 export CONTINUE=${CONTINUE:-}
+
+GREP=${GREP:-grep}
 
 args="$(getopt -n "$0" -l \
     verbose,help,stop,discover,invariant,continue vhxdic $*)" \
@@ -132,12 +136,12 @@ assert_raises() {
 _assert_with_grep() {
     local grep_modifier="$1"
     local output="$($2)"
-    local exitcode="$4" || 0
+    local exitcode=0
     shift 2
 
     while [ $# != 0 ]; do
-    	assert_raises "echo '$output' | $GREP $grep_modifier '$1'" $exitcode || return 1
-    	shift
+        assert_raises "echo '$output' | $GREP $grep_modifier '$1'" $exitcode || return 1
+        shift
     done
 }
 

--- a/tests/commands_test.sh
+++ b/tests/commands_test.sh
@@ -73,13 +73,13 @@ ADDITIONAL USAGE
 
 assert_raises "$src fail" 1
 
-assert_contains "$src --suggest-reviewers" "Suggested code reviewers (based on git history)" 127
+assert_contains "$src --suggest-reviewers" "Suggested code reviewers (based on git history)"
 assert_raises "$src --suggest-reviewers" 0
 
-assert_contains "$src --detailed-git-stats" "Contribution stats" 127
+assert_contains "$src --detailed-git-stats" "Contribution stats"
 assert_raises "$src --detailed-git-stats" 0
 
-assert_contains "$src --commits-per-day" "Git commits per date" 127
+assert_contains "$src --commits-per-day" "Git commits per date"
 assert_raises "$src --commits-per-day" 0
 
 assert_end


### PR DESCRIPTION
Hi,

This PR fixes tests based on `assert_contains`.
If you just specify *any random string* as an argument to the function, the tests just pass, which is not how it supposed to work.
There are few problems discovered in the test script.
Facts:
* `assert_contains` calls `_assert_with_grep` which calls `assert_raises`, which should use `grep` for testing
* `assert_contains` gets exit code as a third argument which is passed to `assert_raises`

Problems:
* The exit code `127` is passed to final `assert_raises` call, but `grep` (according to the man page) does not return such code ever.
* Seems to be that `$GREP` variable was not initialized and being substituted by empty string, so exit code `127` come out from the shell as "command not found" error.
* Testing with exit code seems to be meaningless, since the outcome should be binary: an output contains a string(s), or not.

Fixes:
* Make shell to complain about uninitialized variables (useful for debugging) and assign `$GREP` default value.
* Give up on exit code for `assert_contains`, always test for success (`0`), or return failure (`1`).
* That also gives an ability to test for multiple strings using `assert_contains`.

Now tests work and pass correctly.