### PR TITLE
Change default date to be when git was first invented

### DIFF
--- a/git-quick-stats
+++ b/git-quick-stats
@@ -14,7 +14,7 @@ _since=${_GIT_SINCE:-}
 if [[ -n "${_since}" ]]; then
     _since="--since=$_since"
 else
-    _since="--since=1970-01-01"
+    _since="--since=2005-04-07"
 fi
 
 # End of git log date. Respects all git datetime formats


### PR DESCRIPTION
* The current default date is set to UNIX Epoch time. However, it seems
  some people are possibly having issues with date/time formats within
  their OSes. This commit attempts to fix issue #115 when the default
  date may be too old and cause no output to show