### PR TITLE
Fix escape sequences when outputting to non-TTYs

### DIFF
--- a/git-quick-stats
+++ b/git-quick-stats
@@ -224,12 +224,9 @@ showMenu() {
 # OUTS: None
 ################################################################################
 function optionPicked() {
-    local -r bold=$(tput bold)
-    local -r red=$(tput setaf 1)
-    local -r reset=$(tput sgr0)
-    local msg=${*:-"${reset}Error: No message passed"}
+    local msg=${*:-"Error: No message passed"}
 
-    echo -e "${bold}${red}${msg}${reset}\n"
+    echo -e "${msg}\n"
 }
 
 ################################################################################


### PR DESCRIPTION
* When performing actions such as redirecting the stats to a file,
  the terminal escape sequences for handling colors gets added
  to the top message in the text file. While running commands such
  as sed can fix this, it is inconvenient for users wishing to redirect
  or pipe the stats in a clean way.

  Attempting to use test -t yielded some unexpected results, as well
  as extra logic for handling a non-tty case, so for now, we are
  simply removing the colors from the message so it defaults to
  standard terminal colors and formatting

Fixes #122