### PR TITLE
Replaced grep commit by grep with regex including git sha hash

### DIFF
--- a/git-quick-stats
+++ b/git-quick-stats
@@ -546,7 +546,7 @@ function myDailyStats() {
                        --author="$(git config user.name)" $_merges \
                        --since=$(date "+%Y-%m-%dT00:00:00") \
                        --until=$(date "+%Y-%m-%dT23:59:59") --reverse $_log_options \
-                       | grep commit | wc -l) "commits"
+                       | grep -E "commit [a-f0-9]{40}" | wc -l) "commits"
 }
 
 ################################################################################


### PR DESCRIPTION
Solving #126 

myDailyStats() used grep commit to detect count of commits. This
also increases the count by mentioning commit in the commit
message.

Therefore a grep with regex is used that expects a 40 digit/char
SHA1 hash after the word commit.