### PR TITLE
Misc. fixes on filtering, added commits-by-year

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@ _INSTDIR ?= $(DESTDIR)$(PREFIX)
 BINDIR ?= $(_INSTDIR)/bin
 MANDIR ?= $(_INSTDIR)/share/man
 TASK_DONE = echo -e "\n✓ $@ done\n"
+SHELL := $(shell which bash)
 
 .PHONY: test
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,8 @@
 >
 > Any git repository may contain tons of information about commits, contributors, and files. Extracting this information is not always trivial, mostly because there are a gadzillion options to a gadzillion git commands – I don’t think there is a single person alive who knows them all. Probably not even [Linus Torvalds](https://github.com/torvalds) himself :).
 
-![mainMenuScreenshot](https://user-images.githubusercontent.com/8818630/121750502-8223d600-cada-11eb-94bc-470be4e22ba4.png)
+![mainMenuScreenshot](https://user-images.githubusercontent.com/8818630/154823670-f42a111b-45f4-47fc-aea7-80059827c8e6.png)
+
 
 ## Table of Contents
 
@@ -53,9 +54,9 @@
 
 ## Screenshots
 
-![commitsByWeekdayScreenshot](https://user-images.githubusercontent.com/8818630/121750517-8819b700-cada-11eb-99a0-a72942822da5.png)
+![commitsByWeekdayScreenshot](https://user-images.githubusercontent.com/8818630/154823677-e34ca867-ae61-4755-bf89-c877f809c591.png)
 
-![commitsByHourScreenshot](https://user-images.githubusercontent.com/8818630/121750525-8c45d480-cada-11eb-8054-78716ce6623c.png)
+![commitsByHourScreenshot](https://user-images.githubusercontent.com/8818630/154823679-bdadc26c-c644-4a01-b625-85e330f85d41.png)
 
 ## Usage
 
@@ -207,7 +208,7 @@ You can change to the legacy color scheme by toggling the variable `_MENU_THEME`
 export _MENU_THEME="legacy"
 ```
 
-![legacyThemeScreenshot](https://user-images.githubusercontent.com/8818630/121750530-8f40c500-cada-11eb-808c-5f5fb81801d2.png)
+![legacyThemeScreenshot](https://user-images.githubusercontent.com/8818630/154823711-3dd0c268-f3cb-42e5-9094-0eb8e45d1761.png)
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -119,6 +119,8 @@ LIST OPTIONS
         displays a list of commits per author
     -d, --commits-per-day
         displays a list of commits per day
+    -Y, --commits-by-year
+        displays a list of commits per year
     -m, --commits-by-month
         displays a list of commits per month
     -w, --commits-by-weekday
@@ -281,7 +283,6 @@ sort
 tput
 tr
 uniq
-wc
 ```
 
 ### Dependencies

--- a/git-quick-stats
+++ b/git-quick-stats
@@ -11,13 +11,13 @@ set -o nounset
 set -o errexit
 
 # Beginning git log date. Respects all git datetime formats
-# If $_GIT_SINCE is never set, choose epoch time as that is
-# as far back as git will allow you to go
+# If $_GIT_SINCE is never set, look at the repository to find the first date.
+# NOTE: previously this put the date at the fixed GIT epoch (May 2005)
 _since=${_GIT_SINCE:-}
 if [[ -n "${_since}" ]]; then
     _since="--since=$_since"
 else
-    _since="--since=2005-04-07"
+    _since="--since=$(git log --reverse --format='%ad' | head -n1)"
 fi
 
 # End of git log date. Respects all git datetime formats
@@ -27,7 +27,7 @@ _until=${_GIT_UNTIL:-}
 if [[ -n "${_until}" ]]; then
     _until="--until=$_until"
 else
-    _until="--until=$(date)"
+    _until="--until=$(date '+%a, %d %b %Y %H:%M:%S %Z')"
 fi
 
 # Set files or directories to be excluded in stats
@@ -83,7 +83,7 @@ _theme="${_MENU_THEME:=default}"
 function checkUtils() {
     readonly MSG="not found. Please make sure this is installed and in PATH."
     readonly UTILS="awk basename cat column echo git grep head printf seq sort \
-                    tput tr uniq wc"
+                    tput tr uniq"
 
     for u in $UTILS
     do
@@ -154,6 +154,8 @@ LIST OPTIONS
         displays a list of commits per day
     -m, --commits-by-month
         displays a list of commits per month
+    -Y, --commits-by-year
+        displays a list of commits per year
     -w, --commits-by-weekday
         displays a list of commits per weekday
     -o, --commits-by-hour
@@ -239,13 +241,14 @@ function showMenu() {
     printf %b "${NUMS}   11)${TEXT} Git commits per author\\n"
     printf %b "${NUMS}   12)${TEXT} Git commits per date\\n"
     printf %b "${NUMS}   13)${TEXT} Git commits per month\\n"
-    printf %b "${NUMS}   14)${TEXT} Git commits per weekday\\n"
-    printf %b "${NUMS}   15)${TEXT} Git commits per hour\\n"
-    printf %b "${NUMS}   16)${TEXT} Git commits per hour by author\\n"
-    printf %b "${NUMS}   17)${TEXT} Git commits per timezone\\n"
-    printf %b "${NUMS}   18)${TEXT} Git commits per timezone by author\\n"
+    printf %b "${NUMS}   14)${TEXT} Git commits per year\\n"
+    printf %b "${NUMS}   15)${TEXT} Git commits per weekday\\n"
+    printf %b "${NUMS}   16)${TEXT} Git commits per hour\\n"
+    printf %b "${NUMS}   17)${TEXT} Git commits per hour by author\\n"
+    printf %b "${NUMS}   18)${TEXT} Git commits per timezone\\n"
+    printf %b "${NUMS}   19)${TEXT} Git commits per timezone by author\\n"
     printf %b "\\n${TITLES} Suggest:\\n"
-    printf %b "${NUMS}   19)${TEXT} Code reviewers (based on git history)\\n"
+    printf %b "${NUMS}   20)${TEXT} Code reviewers (based on git history)\\n"
     printf %b "\\n${HELP_TXT}Please enter a menu option or ${EXIT_TXT}press Enter to exit.\\n"
     printf %b "${TEXT}> ${NORMAL}"
     read -r opt
@@ -416,7 +419,7 @@ function myDailyStats() {
                        --author="$(git config user.name)" $_merges \
                        --since=$(date "+%Y-%m-%dT00:00:00") \
                        --until=$(date "+%Y-%m-%dT23:59:59") --reverse $_log_options \
-                       | grep -E "commit [a-f0-9]{40}" | wc -l) "commits"
+                       | grep -cE "commit [a-f0-9]{40}") "commits"
 }
 
 ################################################################################
@@ -619,6 +622,56 @@ function commitsPerDay() {
 }
 
 ################################################################################
+# DESC: Displays a horizontal bar graph based on total commits per year
+# ARGS: None
+# OUTS: None
+################################################################################
+function commitsByYear() {
+    optionPicked "Git commits by year:"
+    local year startYear endYear __since __until
+    startYear=$(echo "$_since" | sed -E 's/^.* ([0-9]{4})( .*)?$/\1/')
+    endYear=$(echo "$_until" | sed -E 's/^.* ([0-9]{4})( .*)?$/\1/')
+
+    echo -e "\tyear\tsum"
+    for year in $(seq "$startYear" "$endYear")
+    do
+        if [ "$year" = "$startYear" ]
+        then
+          __since=$_since
+          __until="--until=$year-12-31"
+        elif [ "$year" = "$endYear" ]
+        then
+          __since="--since=$year-01-01"
+          __until=$_until
+        else
+          __since="--since=$year-01-01"
+          __until="--until=$year-12-31"
+        fi
+
+        echo -en "\t$year\t"
+        git -c log.showSignature=false shortlog -n $_merges --format='%ad %s' \
+            "$__since" "$__until" $_log_options | grep -cE \
+              " \w\w\w [0-9]{1,2} [0-9][0-9]:[0-9][0-9]:[0-9][0-9] $year " \
+                || continue
+    done | awk '{
+        count[$1] = $2
+        total += $2
+    }
+    END{
+        for (year in count) {
+            s="|";
+            if (total > 0) {
+                percent = ((count[year] / total) * 100) / 1.25;
+                for (i = 1; i <= percent; ++i) {
+                    s=s"█"
+                }
+                printf( "\t%s\t%-0s\t%s\n", year, count[year], s );
+            }
+        }
+    }' | sort
+}
+
+################################################################################
 # DESC: Displays a horizontal bar graph based on total commits per month
 # ARGS: None
 # OUTS: None
@@ -626,14 +679,13 @@ function commitsPerDay() {
 function commitsByMonth() {
     optionPicked "Git commits by month:"
     echo -e "\tmonth\tsum"
-    local startYear=$(echo "$_since" | grep -Eo "[0-9]{4}")
-    local endYear=$(echo "$_until" | grep -Eo "[0-9]{4}")
+    local i
     for i in Jan Feb Mar Apr May Jun Jul Aug Sep Oct Nov Dec
     do
         echo -en "\t$i\t"
         git -c log.showSignature=false shortlog -n $_merges --format='%ad %s' \
-            "$_since" "$_until" $_log_options | grep -E "($startYear|$endYear)" \
-            | grep " $i " | wc -l
+            "$_since" "$_until" $_log_options |
+            grep -cE " \w\w\w $i [0-9]{1,2} " || continue
     done | awk '{
         count[$1] = $2
         total += $2
@@ -660,15 +712,13 @@ function commitsByMonth() {
 function commitsByWeekday() {
     optionPicked "Git commits by weekday:"
     echo -e "\tday\tsum"
-    local startYear=$(echo "$_since" | grep -Eo "[0-9]{4}")
-    local endYear=$(echo "$_until" | grep -Eo "[0-9]{4}")
-    local counter=1
+    local i counter=1
     for i in Mon Tue Wed Thu Fri Sat Sun
     do
         echo -en "\t$counter\t$i\t"
         git -c log.showSignature=false shortlog -n $_merges --format='%ad %s' \
-            "$_since" "$_until" $_log_options | grep -E "($startYear|$endYear)" \
-            | grep "$i " | wc -l
+            "$_since" "$_until" $_log_options |
+            grep -cE "^ * $i \w\w\w [0-9]{1,2} " || continue
         counter=$((counter+1))
     done | awk '{
     }
@@ -710,14 +760,13 @@ function commitsByHour() {
     fi
     echo -e "\thour\tsum"
 
-    local startYear=$(echo "$_since" | grep -Eo "[0-9]{4}")
-    local endYear=$(echo "$_until" | grep -Eo "[0-9]{4}")
+    local i
     for i in $(seq -w 0 23)
     do
         echo -ne "\t$i\t"
-            git -c log.showSignature=false shortlog -n $_merges --format='%ad %s' \
-                "${_author}" "$_since" "$_until" $_log_options \
-                | grep -E "($startYear|$endYear)" | grep ' '$i: | wc -l
+        git -c log.showSignature=false shortlog -n $_merges --format='%ad %s' \
+            "${_author}" "$_since" "$_until" $_log_options |
+            grep -cE '[0-9] '$i':[0-9]' || continue
     done | awk '{
         count[$1] = $2
         total += $2
@@ -838,6 +887,7 @@ if [[ "$#" -eq 1 ]]; then
         -C|--contributors) contributors;;
         -a|--commits-per-author) commitsPerAuthor;;
         -d|--commits-per-day) commitsPerDay;;
+        -Y|--commits-by-year ) commitsByYear;;
         -m|--commits-by-month) commitsByMonth;;
         -w|--commits-by-weekday) commitsByWeekday;;
         -o|--commits-by-hour) commitsByHour;;
@@ -911,20 +961,21 @@ while [[ "${opt}" != "" ]]; do
        11) commitsPerAuthor; showMenu;;
        12) commitsPerDay; showMenu;;
        13) commitsByMonth; showMenu;;
-       14) commitsByWeekday; showMenu;;
-       15) commitsByHour; showMenu;;
-       16) author=""
+       14) commitsByYear; showMenu;;
+       15) commitsByWeekday; showMenu;;
+       16) commitsByHour; showMenu;;
+       17) author=""
            while [[ -z "${author}" ]]; do
                read -r -p "Which author? " author
            done
            commitsByHour "${author}"; showMenu;;
-       17) commitsByTimezone; showMenu;;
-       18) author=""
+       18) commitsByTimezone; showMenu;;
+       19) author=""
            while [[ -z "${author}" ]]; do
                read -r -p "Which author? " author
            done
            commitsByTimezone "${author}"; showMenu;;
-       19) suggestReviewers; showMenu;;
+       20) suggestReviewers; showMenu;;
        q|"\n") exit;;
        *) clear; optionPicked "Pick an option from the menu"; showMenu;;
     esac

--- a/git-quick-stats.1
+++ b/git-quick-stats.1
@@ -85,6 +85,11 @@ displays a list of commits per day
 displays a list of commits per month
 .HP
 .PP
+\fB\-Y\fR, \fB\-\-commits\-by\-year\fR
+.IP
+displays a list of commits per year
+.HP
+.PP
 \fB\-w\fR, \fB\-\-commits\-by\-weekday\fR
 .IP
 displays a list of commits per weekday

--- a/tests/assert.sh
+++ b/tests/assert.sh
@@ -79,7 +79,7 @@ assert_end() {
     tests_endtime="$(date +%s%N)"
     # required visible decimal place for seconds (leading zeros if needed)
     local tests_time="$( \
-        printf "%010d" "$(( ${tests_endtime/%N/000000000} 
+        printf "%010d" "$(( ${tests_endtime/%N/000000000}
                             - ${tests_starttime/%N/000000000} ))")"  # in ns
     tests="$tests_ran ${*:+$* }tests"
     [[ -n "$DISCOVERONLY" ]] && echo "collected $tests." && _assert_reset && return
@@ -105,7 +105,7 @@ assert_end() {
 assert() {
     # assert <command> <expected stdout> [stdin]
     (( tests_ran++ )) || :
-    [[ -z "$DISCOVERONLY" ]] || return
+    [[ -z "$DISCOVERONLY" ]] || return 0
     expected=$(echo -ne "${2:-}")
     result="$(eval 2>/dev/null $1 <<< ${3:-})" || true
     if [[ "$result" == "$expected" ]]; then
@@ -115,13 +115,13 @@ assert() {
     result="$(sed -e :a -e '$!N;s/\n/\\n/;ta' <<< "$result")"
     [[ -z "$result" ]] && result="nothing" || result="\"$result\""
     [[ -z "$2" ]] && expected="nothing" || expected="\"$2\""
-    _assert_fail "expected $expected${_indent}got $result" "$1" "$3"
+    _assert_fail "expected $expected${_indent}got $result" "$1" "${3:-}"
 }
 
 assert_raises() {
     # assert_raises <command> <expected code> [stdin]
     (( tests_ran++ )) || :
-    [[ -z "$DISCOVERONLY" ]] || return
+    [[ -z "$DISCOVERONLY" ]] || return 0
     status=0
     (eval $1 <<< ${3:-}) > /dev/null 2>&1 || status=$?
     expected=${2:-0}
@@ -129,7 +129,12 @@ assert_raises() {
         [[ -z "$DEBUG" ]] || echo -n .
         return
     fi
-    _assert_fail "program terminated with code $status instead of $expected" "$1" "$3"
+    _assert_fail "program terminated with code $status instead of $expected" "$1" "${3:-}"
+}
+
+assert_success() {
+    # assert_success <command>
+    assert_raises "$1" 0
 }
 
 # _assert_with_grep <grep modifiers> <command> <expected output...>

--- a/tests/commands_test.sh
+++ b/tests/commands_test.sh
@@ -48,6 +48,8 @@ LIST OPTIONS
         displays a list of commits per day
     -m, --commits-by-month
         displays a list of commits per month
+    -Y, --commits-by-year
+        displays a list of commits per year
     -w, --commits-by-weekday
         displays a list of commits per weekday
     -o, --commits-by-hour
@@ -86,12 +88,19 @@ ADDITIONAL USAGE
 assert_raises "$src fail" 1
 
 assert_contains "$src --suggest-reviewers" "Suggested code reviewers (based on git history)"
-assert_raises "$src --suggest-reviewers" 0
+assert_success "$src --suggest-reviewers"
 
 assert_contains "$src --detailed-git-stats" "Contribution stats"
-assert_raises "$src --detailed-git-stats" 0
+assert_success "$src --detailed-git-stats"
 
 assert_contains "$src --commits-per-day" "Git commits per date"
-assert_raises "$src --commits-per-day" 0
+assert_success "$src --commits-per-day"
+
+assert_startswith "$src --commits-by-year" "Git commits by year"
+assert_success "$src --commits-by-year"
+
+export LC_TIME=POSIX
+assert_startswith "$src --commits-by-year" "Git commits by year"
+assert_success "$src --commits-by-year"
 
 assert_end


### PR DESCRIPTION
- The start date was arbitrary at 2005, changed to actual first commit.
- Filter by years in by-month and by-week was incorrectly used eg #135
- Other greps also could match on [0-9]{4} in commit (hash or message)
- Added commits-by-year histogram