### PR TITLE
Update formatting and sort commits by timezone

### DIFF
--- a/git-quick-stats
+++ b/git-quick-stats
@@ -874,9 +874,9 @@ function commitsByTimezone() {
     fi
 
     echo -e "Commits\tTimeZone"
-    git -c log.showSignature=false shortlog -n $_merges --format='%ad %s' \
+    git -c log.showSignature=false log $_merges --format='%ad %s' \
         "${_author}" "$_since" "$_until" --date=iso $_log_options $_pathspec \
-        | cut -d " " -f 12 | grep -v -e '^[[:space:]]*$' | sort | uniq -c
+        | cut -d " " -f 3 | grep -v -e '^[[:space:]]*$' | sort -n | uniq -c
 }
 
 ################################################################################


### PR DESCRIPTION
I found that on Fedora 37, trying to get commits sorted by timezone gave some weird results. For example, on this repo:

```
[root@279546d667cd git-quick-stats]# git-quick-stats -z
Git commits by timezone:

Commits	TimeZone
      1 "git
      1 #25
      1 #4
      1 %(color
      1 ->
      1 DESTDIR
      1 Git
      1 PREFIX
      1 URLs
      1 X
      1 _exclude
      1 and
      1 args
      2 argument
      1 assert_contains
[...]
```

It seems that even with `--format`,  spacing output from `git shortlog` can vary between distros, which throws off the `cut` command. Running the timezone command in a Fedora container will give the above (the correct field number is 9 in this case), but running on a Ubuntu container works as expected:

```
root@124446510da3:/git-quick-stats# git-quick-stats -z
Git commits by timezone:

Commits	TimeZone
      6 +0000
     81 +0100
     53 +0200
      1 +0300
      2 +0530
      1 +0700
     11 +0800
      1 -0300
     24 -0400
     12 -0500
      2 -0600
      3 -0700
      2 -0800
```

I modified the command to use `git log` instead, which seems to have consistent spacing and works in both cases. I also switched to numeric sorting, so now the timezones count up nicely:

```
Commits	TimeZone
      2 -0800
      3 -0700
      2 -0600
     12 -0500
     25 -0400
      1 -0300
      6 +0000
     81 +0100
     53 +0200
      1 +0300
      2 +0530
      1 +0700
     11 +0800
```