### PR TITLE
fix: Ubuntu does not support `date -j`

### DIFF
--- a/git-quick-stats
+++ b/git-quick-stats
@@ -394,7 +394,7 @@ function changelogs() {
         --date=short "${_author}" "$_since" "$_until" $_log_options $_pathspec \
         | sort -u -r | head -n $_limit \
         | while read DATE; do
-              day=$(date -u -j -f "%Y-%m-%d" "$DATE" "+%A")
+              day=$(date -d "$DATE" "+%A")
               echo -e "\n[$DATE - $day]"
               GIT_PAGER=cat git -c log.showSignature=false log \
                                 --use-mailmap $_merges \


### PR DESCRIPTION
This is required for changelogs.

Resolves #147

---

Only tested on Ubuntu and Windows (MINGW64 from Git Bash):

```bash
$ date --version
date (GNU coreutils) 8.32
…

$ date --help | grep '\-d'
  -d, --date=STRING          display time described by STRING, not 'now'
…
```

Could anyone help to test on FreeBSD?

