### PR TITLE
Handle error where BSD date is being used

### DIFF
--- a/git-quick-stats
+++ b/git-quick-stats
@@ -89,6 +89,21 @@ function checkUtils() {
     do
         command -v "$u" >/dev/null 2>&1 || { echo >&2 "$u ${MSG}"; exit 1; }
     done
+
+    # NOTE: The --version flag is only available in GNU date which is required
+    # for how the current date/time strings are used in this shell script.
+    # To fully support the legacy BSD date found in a default install within
+    # macOS and older distributions of Linux and Unix, a handful of helper
+    # functions can probably be created to handle every case of incompatibility
+    # between the two. Until that's implemented, it is probably best to warn
+    # the user that this will not work rather than having it silently bomb out
+    # during runtime.
+    if ! date --version >/dev/null 2>&1; then
+        echo "ERROR: You must have GNU date installed."
+        echo "If you're on macOS, please use brew to install this utility."
+        echo "Make sure the GNU version of date is symlinked to 'date', too."
+        exit 1
+    fi
 }
 
 ################################################################################
@@ -107,16 +122,17 @@ function optionPicked() {
 # ARGS: $* (required): String
 # OUTS: String
 ################################################################################
-format_date() {
-  local date="${1}"
-  local outf="${2}"
-  local datef="${3:-"%b %d %H:%M:%S %Y %Z"}"  # Tue Oct 24 13:34:22 2023 +0300
-  if [[ "$OSTYPE" == "linux-gnu"* ]]; then
+function format_date() {
+    # NOTE: While this works where it's implemented within the changelogs()
+    # function the first time, it then bombs out when it reaches the -d flag
+    # in the second half of that same code as BSD date cannot handle -d, nor
+    # can it handle a string such as DATE - 1 day.
+    local date="${1}"
+    local outf="${2}"
+    local datef="${3:-"%b %d %H:%M:%S %Y %Z"}"  # Tue Oct 24 13:34:22 2023 +0300
     local resp="$(date -d "${date}" "+${outf}")"
-  elif [[ "$OSTYPE" == "darwin"* ]]; then
-    local resp="$(date -j -f "${datef}" "${date}" "+${outf}")"
-  fi
-  printf "%s" "${resp}"
+
+    printf "%s" "${resp}"
 }
 
 ################################################################################

--- a/git-quick-stats.1
+++ b/git-quick-stats.1
@@ -1,4 +1,4 @@
-.TH git-quick-stats "1" "June 2021" "git-quick-stats" "User Commands"
+.TH git-quick-stats "1" "April 2024" "git-quick-stats" "User Commands"
 .SH NAME
 .B git\-quick\-stats
 \- Simple and efficient way to access various stats in a git repository.
@@ -95,7 +95,7 @@ displays a list of commits per year
 displays a list of commits per weekday
 .HP
 .PP
-\fB\-W\fR, \fB\-\-commits\-by\author\-by\-weekday\fR
+\fB\-W\fR, \fB\-\-commits\-by\-author\-by\-weekday\fR
 .IP
 displays a list of commits per weekday by author
 .HP

--- a/tests/commands_test.sh
+++ b/tests/commands_test.sh
@@ -1,5 +1,13 @@
 #!/bin/bash
 
+# Verify we are in a git repo. Create one if not
+# FIXME: All the paths are hardcoded currently and will break if anything
+# in this chain moves or gets executed elsewhere. Adjust all of these so
+# pathing does not matter as much such as creating a TOP variable that
+# does something like TOP=$(cd "$(dirname "$0")" || exit ; pwd -P)
+# or maybe leverages Make to handle these as test targets
+./tests/test-git/resetgit
+
 . tests/assert.sh -v
 
 src="./git-quick-stats"

--- a/tests/test-git/resetgit
+++ b/tests/test-git/resetgit
@@ -1,17 +1,16 @@
 #!/bin/sh
-# Initialises a new local Git repo for test purpose.
-if test -d ../test-git/.git; then rm -Rf ../test-git/.git; fi
-#mkdir test-git
-cd ../test-git
-git init
-git config user.name "$(printf %s 'Test Git,\nfor test purpose')"
-git config user.email "TestGit\o/@example.org"
+# Initialises a new local Git repo for test purpose if one does not exist already
+if ! git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+    {
+        git init
+        git config user.name "$(printf %s 'Test Git,\nfor test purpose')"
+        git config user.email "TestGit\o/@example.org"
 
-#printf '\n[user]\nname = test-git\nemail = test-git@example.org\n'> .git/config
-printf 'test-git\n========\n' > README.md
-git add README.md
-git commit -m 'added readme (o\w/o)' -m 'in markdown, no \r\n, only \n' -m 'a very "simple" readme'
-testChars="$(printf 'tab [%b] form feed [%b] line feed [%b] carriage return [%b]' '\x09' '\x0C' '\x0A' '\x0D')"
-#printf '# testChars [%s]\n' "$testChars">&2
-git notes add -m 'Some notes' -m 'out of ascii: été au cœur' -m "$testChars"
-git log
+        printf 'test-git\n========\n' > README.md
+        git add README.md
+        git commit -m 'added readme (o\w/o)' -m 'in markdown, no \r\n, only \n' -m 'a very "simple" readme'
+        testChars="$(printf 'tab [%b] form feed [%b] line feed [%b] carriage return [%b]' '\x09' '\x0C' '\x0A' '\x0D')"
+        git notes add -m 'Some notes' -m 'out of ascii: été au cœur' -m "$testChars"
+        git log
+    } >/dev/null 2>&1
+fi


### PR DESCRIPTION
* Users on macOS and other older distributions of Linux and Unix cannot fully utilize this application as a handful of date/time strings in here are specific to the GNU utility found on most modern version of Linux.

  Until every date/time case is handled between the BSD version of date and the GNU version of date, let's error out akin to how we do it if the user doesn't have every utility installed to run this script.

  Users can get around this by using package managers on macOS such as homebrew, macports, etc and making sure that 'date' points to the GNU version of date instead of the BSD version. Linux and Unix users can get around this by installing the GNU version of date, as well.

* Removed checking OSTYPE in the format_date() function as checking if someone is on a machine that identifies as Darwin is not enough to handle other edge cases where an older version of BSD date might be present on the system.

Important: While this does not close tickets like #160 and #163 (these two tickets should be combined as it's the same bug), it should hopefully prevent further tickets from being created and avoid overall confusion as to what's going on.