### PR TITLE
Fix stats for situation where there are no inserts / deletes

### DIFF
--- a/git-quick-stats
+++ b/git-quick-stats
@@ -337,11 +337,15 @@ function detailedGitStats() {
         if(more["total"] > 0) {
             printf "\t  insertions:    %d\t(%.0f%%)\n", more[author], \
                 (more[author] / more["total"] * 100)
+        } else {
+            printf "\t  insertions:    %d\t(%.0f%%)\n", 0, 0
         }
 
         if(less["total"] > 0) {
             printf "\t  deletions:     %d\t(%.0f%%)\n", less[author], \
                 (less[author] / less["total"] * 100)
+        } else {
+            printf "\t  deletions:     %d\t(%.0f%%)\n", 0, 0
         }
 
         if(file["total"] > 0) {
@@ -498,11 +502,15 @@ function csvOutput() {
         if(more["total"] > 0) {
             printf "%d,%.0f%%,", more[author], \
                 (more[author] / more["total"] * 100)
+        } else {
+            printf "0,0%%,"
         }
 
         if(less["total"] > 0) {
             printf "%d,%.0f%%,", less[author], \
                 (less[author] / less["total"] * 100)
+        } else {
+            printf "0,0%%,"
         }
 
         if(file["total"] > 0) {


### PR DESCRIPTION
This is mainly a problem for the CSV output as I've been parsing it in a separate script for something else. But I've added the fix for the detailed stats as well. 

The printStats() function does not print anything if there were no lines removed (or added), which means the data in the output of the CSV will not be in the correct column. This changes that to print 0 and 0% in those places. 

Before : 
```
_GIT_UNTIL="2024-09-30" _GIT_SINCE="2023-09-01" _GIT_BRANCH=master git-quick-stats -V
author,insertions,insertions_per,deletions,deletions_per,files,files_per,commits,commits_per,lines_changed,lines_changed_per
Some One <sone@email.com>,317971,100%,655,100%,1,100%,317971,100%

```
After :

```
_GIT_UNTIL="2024-09-30" _GIT_SINCE="2023-09-01" _GIT_BRANCH=master git-quick-stats -V
author,insertions,insertions_per,deletions,deletions_per,files,files_per,commits,commits_per,lines_changed,lines_changed_per
 Some One <sone@email.com>,317971,100%,0,0%,655,100%,1,100%,317971,100%
```