### PR TITLE
Fix help-message in test

### DIFF
--- a/tests/commands_test.sh
+++ b/tests/commands_test.sh
@@ -95,7 +95,9 @@ ADDITIONAL USAGE
     You can set _MENU_THEME to display the legacy color scheme
         ex: export _MENU_THEME=legacy
     You can set _GIT_BRANCH to set the branch of the stats
-        ex: export _GIT_BRANCH=master"
+        ex: export _GIT_BRANCH=master
+    You can set _GIT_IGNORE_AUTHORS to filter out specific authors
+        ex: export _GIT_IGNORE_AUTHORS=\"(author1|author2)\""
 
 assert_raises "$src fail" 1
 


### PR DESCRIPTION
I had the same problem as reported in #185.

The first test failed because #184 updated the help-message to include the new option to ignore authors but did not update the expected test-output.
I have updated the expected message in the tests to include this new output, making the tests pass.
This fixes #185.